### PR TITLE
Semester Projects Page + Airtable Integration

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,7 @@
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
+
 module.exports = {
   siteMetadata: {
     title: `Codebase`,
@@ -30,7 +34,7 @@ module.exports = {
     {
       resolve: "gatsby-source-airtable",
       options: {
-        apiKey: process.env.API_KEY,
+        apiKey: process.env.AIRTABLE_API_KEY,
         tables: [
           {
             baseId: "appMWiDJv5hAFHvHA",

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,6 +27,19 @@ module.exports = {
         icon: `src/images/cb-icon.png`, // This path is relative to the root of the site.
       },
     },
+    {
+      resolve: "gatsby-source-airtable",
+      options: {
+        apiKey: process.env.API_KEY,
+        tables: [
+          {
+            baseId: "appMWiDJv5hAFHvHA",
+            tableName: "Projects",
+            tableView: "Current",
+          },
+        ],
+      },
+    },
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3526,6 +3526,100 @@
         "indent-string": "^4.0.0"
       }
     },
+    "airtable": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.8.1.tgz",
+      "integrity": "sha512-Cxw55ta1olDwDERz++HFJOBX6LONtg+d7+wOcYguqI4PR4P5RHmgjTbY8tPKgLHb8U3FVOyAbpb7NpLRSnLGgg==",
+      "requires": {
+        "es6-promise": "4.2.8",
+        "lodash": "4.17.15",
+        "request": "2.88.0",
+        "xhr": "2.3.3"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "global": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+          "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+          "requires": {
+            "min-document": "^2.19.0",
+            "process": "~0.5.1"
+          }
+        },
+        "process": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "xhr": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.3.3.tgz",
+          "integrity": "sha1-rWuBDgkXznK17HBPXUHxUDuOdSQ=",
+          "requires": {
+            "global": "~4.3.0",
+            "is-function": "^1.0.1",
+            "parse-headers": "^2.0.0",
+            "xtend": "^4.0.0"
+          }
+        }
+      }
+    },
     "ajv": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
@@ -7544,6 +7638,11 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -9698,6 +9797,16 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
           "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
         }
+      }
+    },
+    "gatsby-source-airtable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gatsby-source-airtable/-/gatsby-source-airtable-2.1.1.tgz",
+      "integrity": "sha512-VLTB9iny0Vqf9ee/Piwl1LLRC++wtGyO9ZBMEISgXxsamwpQ0/08J8jL2zB+EDe5v4KRPRLSlEqb4aO1kYCBIA==",
+      "requires": {
+        "airtable": "^0.8.0",
+        "bluebird": "^3.5.4",
+        "mime": "^2.4.4"
       }
     },
     "gatsby-source-filesystem": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby-plugin-offline": "^3.2.7",
     "gatsby-plugin-react-helmet": "^3.3.2",
     "gatsby-plugin-sharp": "^2.6.9",
+    "gatsby-source-airtable": "^2.1.1",
     "gatsby-source-filesystem": "^2.3.8",
     "gatsby-transformer-sharp": "^2.5.3",
     "prop-types": "^15.7.2",

--- a/src/components/home/home-projects.js
+++ b/src/components/home/home-projects.js
@@ -1,31 +1,39 @@
 import React from "react"
 import { Link } from "gatsby"
 import ProjectsSection from "../projects-section"
-import { CLIENT_DESCRIPTION, MENTORED_DESCRIPTION } from "../../constants"
+import Container from "react-bootstrap/Container"
 
 import "../../styles/home-projects.css"
+import "../../styles/layout.css"
 
 const HomeProjects = () => {
   return (
-    <div className="container cb-home-projects">
+    <Container className="cb-home-projects">
       <h1 className="cb-home-projects-title">THIS SEMESTER'S PROJECTS</h1>
 
       <ProjectsSection
         heading="Client projects"
-        description={CLIENT_DESCRIPTION}
+        description={
+          "Our client teams work with industry partners to build products " +
+          "ranging from full stack web development to machine learning."
+        }
         client={true}
       />
 
       <ProjectsSection
         heading="Mentored project"
-        description={MENTORED_DESCRIPTION}
+        description={
+          "Our mentored team focuses on learning the essentials of " +
+          "software development and simultaneously develops an full-stack " +
+          "web application for a non-profit organization."
+        }
         client={false}
       />
 
       <Link className="cb-orange-link" to="projects">
         Check out how each project works →
       </Link>
-    </div>
+    </Container>
   )
 }
 

--- a/src/components/home/home-projects.js
+++ b/src/components/home/home-projects.js
@@ -1,0 +1,32 @@
+import React from "react"
+import { Link } from "gatsby"
+import ProjectsSection from "../projects-section"
+import { CLIENT_DESCRIPTION, MENTORED_DESCRIPTION } from "../../constants"
+
+import "../../styles/home-projects.css"
+
+const HomeProjects = () => {
+  return (
+    <div className="container cb-home-projects">
+      <h1 className="cb-home-projects-title">THIS SEMESTER'S PROJECTS</h1>
+
+      <ProjectsSection
+        heading="Client projects"
+        description={CLIENT_DESCRIPTION}
+        client={true}
+      />
+
+      <ProjectsSection
+        heading="Mentored project"
+        description={MENTORED_DESCRIPTION}
+        client={false}
+      />
+
+      <Link className="cb-orange-link" to="projects">
+        Check out how each project works →
+      </Link>
+    </div>
+  )
+}
+
+export default HomeProjects

--- a/src/components/project-card.js
+++ b/src/components/project-card.js
@@ -1,6 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import Col from "react-bootstrap/col"
+import Card from "react-bootstrap/Card"
 
 import "../styles/project-card.css"
 
@@ -13,17 +14,17 @@ const ProjectCard = ({
 }) => {
   return (
     <Col md={6} sm={12} className="cb-project-col">
-      <div className="card cb-project-card">
-        <div className="card-body cb-project-card-body">
-          <a href={hyperlink}>
+      <Card className="cb-project-card">
+        <Card.Body className="cb-project-card-body">
+          <a target="_blank" rel="noopener noreferrer" href={hyperlink}>
             <img className="cb-project-logo" src={logoUrl} alt={altText}></img>
           </a>
           <div className="cb-project-type">
             <b>{projectType}</b>
           </div>
           <p className="cb-project-text">{description}</p>
-        </div>
-      </div>
+        </Card.Body>
+      </Card>
     </Col>
   )
 }

--- a/src/components/project-card.js
+++ b/src/components/project-card.js
@@ -5,13 +5,15 @@ import "../styles/project-card.css"
 
 const ProjectCard = ({ logoUrl, projectType, description, altText }) => {
   return (
-    <div className="card cb-project-card">
-      <div className="card-body">
-        <img className="cb-project-logo" src={logoUrl} alt={altText}></img>
-        <p className="cb-project-type">
-          <b>{projectType}</b>
-        </p>
-        <p className="cb-project-text">{description}</p>
+    <div className="col-md-6 col-sm-12 cb-project-col">
+      <div className="card cb-project-card">
+        <div className="card-body cb-project-card-body">
+          <img className="cb-project-logo" src={logoUrl} alt={altText}></img>
+          <div className="cb-project-type">
+            <b>{projectType}</b>
+          </div>
+          <p className="cb-project-text">{description}</p>
+        </div>
       </div>
     </div>
   )

--- a/src/components/project-card.js
+++ b/src/components/project-card.js
@@ -1,0 +1,27 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import "../styles/project-card.css"
+
+const ProjectCard = ({ logoUrl, projectType, description, altText }) => {
+  return (
+    <div className="card cb-project-card">
+      <div className="card-body">
+        <img className="cb-project-logo" src={logoUrl} alt={altText}></img>
+        <p className="cb-project-type">
+          <b>{projectType}</b>
+        </p>
+        <p className="cb-project-text">{description}</p>
+      </div>
+    </div>
+  )
+}
+
+ProjectCard.propTypes = {
+  logoUrl: PropTypes.string,
+  projectType: PropTypes.string,
+  description: PropTypes.string,
+  altText: PropTypes.string,
+}
+
+export default ProjectCard

--- a/src/components/project-card.js
+++ b/src/components/project-card.js
@@ -3,12 +3,20 @@ import PropTypes from "prop-types"
 
 import "../styles/project-card.css"
 
-const ProjectCard = ({ logoUrl, projectType, description, altText }) => {
+const ProjectCard = ({
+  logoUrl,
+  projectType,
+  description,
+  hyperlink,
+  altText,
+}) => {
   return (
     <div className="col-md-6 col-sm-12 cb-project-col">
       <div className="card cb-project-card">
         <div className="card-body cb-project-card-body">
-          <img className="cb-project-logo" src={logoUrl} alt={altText}></img>
+          <a href={hyperlink}>
+            <img className="cb-project-logo" src={logoUrl} alt={altText}></img>
+          </a>
           <div className="cb-project-type">
             <b>{projectType}</b>
           </div>

--- a/src/components/project-card.js
+++ b/src/components/project-card.js
@@ -1,5 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
+import Col from "react-bootstrap/col"
 
 import "../styles/project-card.css"
 
@@ -11,7 +12,7 @@ const ProjectCard = ({
   altText,
 }) => {
   return (
-    <div className="col-md-6 col-sm-12 cb-project-col">
+    <Col md={6} sm={12} className="cb-project-col">
       <div className="card cb-project-card">
         <div className="card-body cb-project-card-body">
           <a href={hyperlink}>
@@ -23,7 +24,7 @@ const ProjectCard = ({
           <p className="cb-project-text">{description}</p>
         </div>
       </div>
-    </div>
+    </Col>
   )
 }
 

--- a/src/components/projects-section.js
+++ b/src/components/projects-section.js
@@ -1,5 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
+import Row from "react-bootstrap/row"
+import Col from "react-bootstrap/col"
 import { graphql, useStaticQuery } from "gatsby"
 import ProjectCard from "./project-card"
 
@@ -52,9 +54,7 @@ const ProjectsSection = ({ heading, description, client }) => {
       })
       .reduce((projectRow, _projectCol, i, projectCols) => {
         if (i % 2 === 0) {
-          projectRow.push(
-            <div className="row">{projectCols.slice(i, i + 2)}</div>
-          )
+          projectRow.push(<Row>{projectCols.slice(i, i + 2)}</Row>)
         }
         return projectRow
       }, [])
@@ -63,14 +63,14 @@ const ProjectsSection = ({ heading, description, client }) => {
 
   return (
     <div>
-      <div className="row">
-        <div className="col">
+      <Row>
+        <Col>
           <div className="cb-projects-section">
             <h2 className="cb-projects-section-title">{heading}</h2>
             <p className="cb-projects-section-blurb">{description}</p>
           </div>
-        </div>
-      </div>
+        </Col>
+      </Row>
       {showProjectCards()}
     </div>
   )

--- a/src/components/projects-section.js
+++ b/src/components/projects-section.js
@@ -19,6 +19,7 @@ const ProjectsSection = ({ heading, description, client }) => {
               }
               Type
               Description
+              Hyperlink
             }
           }
         }
@@ -38,12 +39,13 @@ const ProjectsSection = ({ heading, description, client }) => {
     const projectCards = edges
       .filter(edge => !!edge.node.data.Client === client)
       .map(edge => {
-        const { Logo, Type, Description, Company } = edge.node.data
+        const { Logo, Type, Description, Hyperlink, Company } = edge.node.data
         return (
           <ProjectCard
             logoUrl={Logo[0].url}
             projectType={Type}
             description={Description}
+            hyperlink={Hyperlink}
             altText={Company}
           />
         )

--- a/src/components/projects-section.js
+++ b/src/components/projects-section.js
@@ -29,23 +29,23 @@ const ProjectsSection = ({ heading, description, client }) => {
   const showProjectCards = () => {
     const { edges } = currentProjects.allAirtable
 
-    // This chain of functions does three things
-    //   1. Filter out projects based on whether client or mentored
-    //   2. Create a ProjectCard with the CMS info and wrap in a col
-    //   3. Wrap every two columns in a row
+    /**
+     * This chain of functions does three things
+     *  1. Filter out projects based on whether client or mentored
+     *  2. Create a ProjectCard with the Airtable CMS info
+     *  3. Wrap every two columns in a row
+     */
     const projectCards = edges
       .filter(edge => !!edge.node.data.Client === client)
       .map(edge => {
         const { Logo, Type, Description, Company } = edge.node.data
         return (
-          <div className="col">
-            <ProjectCard
-              logoUrl={Logo[0].url}
-              projectType={Type}
-              description={Description}
-              altText={Company}
-            />
-          </div>
+          <ProjectCard
+            logoUrl={Logo[0].url}
+            projectType={Type}
+            description={Description}
+            altText={Company}
+          />
         )
       })
       .reduce((projectRow, _projectCol, i, projectCols) => {

--- a/src/components/projects-section.js
+++ b/src/components/projects-section.js
@@ -62,10 +62,10 @@ const ProjectsSection = ({ heading, description, client }) => {
   }
 
   return (
-    <div>
+    <div className="cb-projects-section">
       <Row>
         <Col>
-          <div className="cb-projects-section">
+          <div className="cb-projects-section-header">
             <h2 className="cb-projects-section-title">{heading}</h2>
             <p className="cb-projects-section-blurb">{description}</p>
           </div>

--- a/src/components/projects-section.js
+++ b/src/components/projects-section.js
@@ -1,0 +1,83 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { graphql, useStaticQuery } from "gatsby"
+import ProjectCard from "./project-card"
+
+import "../styles/projects-section.css"
+
+const ProjectsSection = ({ heading, description, client }) => {
+  const currentProjects = useStaticQuery(graphql`
+    query {
+      allAirtable(filter: { table: { eq: "Projects" } }) {
+        edges {
+          node {
+            data {
+              Company
+              Client
+              Logo {
+                url
+              }
+              Type
+              Description
+            }
+          }
+        }
+      }
+    }
+  `)
+
+  const showProjectCards = () => {
+    const { edges } = currentProjects.allAirtable
+
+    // This chain of functions does three things
+    //   1. Filter out projects based on whether client or mentored
+    //   2. Create a ProjectCard with the CMS info and wrap in a col
+    //   3. Wrap every two columns in a row
+    const projectCards = edges
+      .filter(edge => !!edge.node.data.Client === client)
+      .map(edge => {
+        const { Logo, Type, Description, Company } = edge.node.data
+        return (
+          <div className="col">
+            <ProjectCard
+              logoUrl={Logo[0].url}
+              projectType={Type}
+              description={Description}
+              altText={Company}
+            />
+          </div>
+        )
+      })
+      .reduce((projectRow, _projectCol, i, projectCols) => {
+        if (i % 2 === 0) {
+          projectRow.push(
+            <div className="row">{projectCols.slice(i, i + 2)}</div>
+          )
+        }
+        return projectRow
+      }, [])
+    return projectCards
+  }
+
+  return (
+    <div>
+      <div className="row">
+        <div className="col">
+          <div className="cb-projects-section">
+            <h2 className="cb-projects-section-title">{heading}</h2>
+            <p className="cb-projects-section-blurb">{description}</p>
+          </div>
+        </div>
+      </div>
+      {showProjectCards()}
+    </div>
+  )
+}
+
+ProjectsSection.propTypes = {
+  heading: PropTypes.string,
+  description: PropTypes.string,
+  client: PropTypes.bool,
+}
+
+export default ProjectsSection

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,4 +11,10 @@ const BaseBehavior = Object.freeze({
   GROWTH: 4,
 })
 
-export { Theme, BaseBehavior }
+const CLIENT_DESCRIPTION =
+  "Our client teams work with industry partners to build products ranging from full stack web development to machine learning."
+
+const MENTORED_DESCRIPTION =
+  "Our mentored team focuses on learning the essentials of software development and simultaneously develops an full-stack web application for a non-profit organization."
+
+export { Theme, BaseBehavior, CLIENT_DESCRIPTION, MENTORED_DESCRIPTION }

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,10 +11,4 @@ const BaseBehavior = Object.freeze({
   GROWTH: 4,
 })
 
-const CLIENT_DESCRIPTION =
-  "Our client teams work with industry partners to build products ranging from full stack web development to machine learning."
-
-const MENTORED_DESCRIPTION =
-  "Our mentored team focuses on learning the essentials of software development and simultaneously develops an full-stack web application for a non-profit organization."
-
-export { Theme, BaseBehavior, CLIENT_DESCRIPTION, MENTORED_DESCRIPTION }
+export { Theme, BaseBehavior }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,12 +3,14 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { Theme } from "../constants"
 import HomeHeader from "../components/home/home-header"
+import HomeProjects from "../components/home/home-projects"
 
 const IndexPage = ({ location }) => {
   return (
     <Layout theme={Theme.DEFAULT}>
       <SEO title="Home" />
       <HomeHeader />
+      <HomeProjects />
     </Layout>
   )
 }

--- a/src/styles/home-projects.css
+++ b/src/styles/home-projects.css
@@ -6,7 +6,7 @@
 .cb-home-projects {
   font-family: "Circular Std Book", sans-serif;
   font-weight: 450;
-  max-width: 750px;
+  max-width: 780px;
 }
 
 .cb-home-projects-title {
@@ -21,4 +21,5 @@
   font-size: 14px;
   line-height: 18px;
   text-decoration-line: underline;
+  line-height: 28px;
 }

--- a/src/styles/home-projects.css
+++ b/src/styles/home-projects.css
@@ -16,4 +16,5 @@
   font-size: 15px;
   line-height: 18px;
   margin-top: 5%;
+  margin-bottom: 0;
 }

--- a/src/styles/home-projects.css
+++ b/src/styles/home-projects.css
@@ -7,19 +7,13 @@
   font-family: "Circular Std Book", sans-serif;
   font-weight: 450;
   max-width: 780px;
+  margin-top: 40px;
+  margin-bottom: 40px;
 }
 
 .cb-home-projects-title {
   color: #80868b;
-  font-size: 14px;
+  font-size: 15px;
   line-height: 18px;
   margin-top: 5%;
-}
-
-.cb-orange-link {
-  color: #f77b6f;
-  font-size: 14px;
-  line-height: 18px;
-  text-decoration-line: underline;
-  line-height: 28px;
 }

--- a/src/styles/home-projects.css
+++ b/src/styles/home-projects.css
@@ -1,0 +1,24 @@
+@font-face {
+  font-family: "Circular Std Book";
+  src: url("../fonts/CircularStd-Book.otf") format("opentype");
+}
+
+.cb-home-projects {
+  font-family: "Circular Std Book", sans-serif;
+  font-weight: 450;
+  max-width: 750px;
+}
+
+.cb-home-projects-title {
+  color: #80868b;
+  font-size: 14px;
+  line-height: 18px;
+  margin-top: 5%;
+}
+
+.cb-orange-link {
+  color: #f77b6f;
+  font-size: 14px;
+  line-height: 18px;
+  text-decoration-line: underline;
+}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,3 +1,20 @@
 body {
   margin: 0;
 }
+
+.cb-orange-link {
+  color: #f77b6f;
+  font-size: 15px;
+  line-height: 18px;
+  text-decoration-line: underline;
+  line-height: 28px;
+}
+
+.cb-orange-link:hover {
+  opacity: 0.8;
+  color: #f77b6f;
+  transition: opacity 0.2s ease-out;
+  -moz-transition: opacity 0.2s ease-out;
+  -webkit-transition: opacity 0.2s ease-out;
+  -o-transition: opacity 0.2s ease-out;
+}

--- a/src/styles/project-card.css
+++ b/src/styles/project-card.css
@@ -20,7 +20,7 @@
 }
 
 .cb-project-logo {
-  height: 18px;
+  height: 22px;
   border-radius: 3px;
 }
 

--- a/src/styles/project-card.css
+++ b/src/styles/project-card.css
@@ -1,0 +1,27 @@
+@font-face {
+  font-family: "Circular Std Book";
+  src: url("../fonts/CircularStd-Book.otf") format("opentype");
+}
+
+.cb-project-card {
+  width: 360px;
+  height: 180px;
+}
+
+.cb-project-logo {
+  height: 18px;
+  border-radius: 3px;
+}
+
+.cb-project-text {
+  max-width: 300px;
+  font-family: "Circular Std Book", sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  line-height: 18px;
+  color: #80868b;
+}
+
+.cb-project-type {
+  color: #2f2f30;
+}

--- a/src/styles/project-card.css
+++ b/src/styles/project-card.css
@@ -3,9 +3,20 @@
   src: url("../fonts/CircularStd-Book.otf") format("opentype");
 }
 
+.cb-project-col {
+  margin: 12px 0px;
+}
+
 .cb-project-card {
-  width: 360px;
-  height: 180px;
+  max-width: 360px;
+  height: 200px;
+  padding: 0px;
+}
+
+.cb-project-card-body {
+  padding: 25px 35px 30px;
+  font-family: "Circular Std Book", sans-serif;
+  font-size: 14px;
 }
 
 .cb-project-logo {
@@ -13,10 +24,13 @@
   border-radius: 3px;
 }
 
+.cb-project-type {
+  margin-top: 16px;
+  margin-bottom: 10px;
+}
+
 .cb-project-text {
   max-width: 300px;
-  font-family: "Circular Std Book", sans-serif;
-  font-size: 14px;
   font-style: normal;
   line-height: 18px;
   color: #80868b;

--- a/src/styles/project-card.css
+++ b/src/styles/project-card.css
@@ -9,14 +9,14 @@
 
 .cb-project-card {
   max-width: 360px;
-  height: 200px;
+  height: 210px;
   padding: 0px;
 }
 
 .cb-project-card-body {
   padding: 25px 35px 30px;
   font-family: "Circular Std Book", sans-serif;
-  font-size: 14px;
+  font-size: 15px;
 }
 
 .cb-project-logo {

--- a/src/styles/project-card.css
+++ b/src/styles/project-card.css
@@ -20,7 +20,7 @@
 }
 
 .cb-project-logo {
-  height: 22px;
+  height: 20px;
   border-radius: 3px;
 }
 

--- a/src/styles/projects-section.css
+++ b/src/styles/projects-section.css
@@ -1,0 +1,15 @@
+.cb-projects-section {
+  max-width: 600px;
+}
+
+.cb-projects-section-title {
+  color: #2f2f30;
+  font-size: 17px;
+  line-height: 22px;
+}
+
+.cb-projects-section-blurb {
+  color: #80868b;
+  font-size: 14px;
+  line-height: 18px;
+}

--- a/src/styles/projects-section.css
+++ b/src/styles/projects-section.css
@@ -3,6 +3,8 @@
 }
 
 .cb-projects-section-title {
+  margin-top: 10px;
+  margin-bottom: 13px;
   color: #2f2f30;
   font-size: 17px;
   line-height: 22px;

--- a/src/styles/projects-section.css
+++ b/src/styles/projects-section.css
@@ -12,6 +12,6 @@
 
 .cb-projects-section-blurb {
   color: #80868b;
-  font-size: 14px;
+  font-size: 15px;
   line-height: 18px;
 }

--- a/src/styles/projects-section.css
+++ b/src/styles/projects-section.css
@@ -1,4 +1,9 @@
 .cb-projects-section {
+  margin: 15px 0 10px;
+  padding-bottom: 5px;
+}
+
+.cb-projects-section-header {
   max-width: 600px;
 }
 


### PR DESCRIPTION
Fixes #10.

Two main changes here Lmk if breaking it into two PRs would be preferred since this is quite a large diff.
1. Connect to our Airtable with `gatsby-source-airtable`[0], where I've created a content management system[1] where we can easily edit information semester-to-semester instead of redeploying.
2. Added the "current semester projects" to the homepage. Screenshots below.

Desktop:
![image](https://user-images.githubusercontent.com/36896271/86208339-37a58580-bb25-11ea-91dc-7ed63934fa3c.png)


Mobile:
![image](https://user-images.githubusercontent.com/36896271/86208756-ffeb0d80-bb25-11ea-9d1b-e8600d64deb5.png)


Couple notes:
- Airtable API key is stored as an environment variable, to test it locally you can find it here[2] or just DM me
- I moved the client and mentored project descriptions to the `constants.js` file so we could easily keep track, not sure if this was the move
- I used `<Row>` instead of `<div className="row">`, since we're refactoring it out anyway
- Feel free to roast my styling lol I literally gained more than half of my CSS knowledge today
- Why does prettier not put semicolons :'(


[0] https://www.gatsbyjs.org/packages/gatsby-source-airtable/
[1] https://airtable.com/tblE3s4RGMyDb0Ljq/viweuitnHTuaS5NWd
[2] https://airtable.com/appMWiDJv5hAFHvHA/api/docs#javascript/authentication